### PR TITLE
Handle Unassigned state for connectors

### DIFF
--- a/src/main/kotlin/controllers/Connectors.kt
+++ b/src/main/kotlin/controllers/Connectors.kt
@@ -25,6 +25,7 @@ internal suspend fun connectorsApi(host: String, port: Int, connectorName: Strin
 fun checkConnectorHealth(connector: Connector){
 	if (connector.connector.state != WORKER_STATE.RUNNING &&
 		connector.connector.state != WORKER_STATE.PAUSED &&
+		connector.connector.state != WORKER_STATE.UNASSIGNED &&
 		connector.connector.state != WORKER_STATE.STOPPED)
 		connectorDown(connector.name)
 

--- a/src/main/kotlin/utils/Constants.kt
+++ b/src/main/kotlin/utils/Constants.kt
@@ -17,6 +17,7 @@ object WORKER_STATE {
 	const val RUNNING = "RUNNING"
 	const val PAUSED = "PAUSED"
 	const val STOPPED = "STOPPED"
+	const val UNASSIGNED = "UNASSIGNED"
 	const val FAILED = "FAILED"
 }
 


### PR DESCRIPTION
This commit handles UNASSIGNED state of connectors, whenever a connector is added or deleted.

This prevents the false negative alert emails when connectors are added or deleted. (The default nature of Kakfa connect is to rebalance the connectors when a new connector is added or deleted, leading to the connector going into a UNASSIGNED state)